### PR TITLE
FIPS and Self Signed Certs

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,8 +202,7 @@ nsstools::add_cert { <title>:
 
  * `certdir`
 
-    `String`/absolute path required
-
+    `String`/absolute path required 
     Absolute path to the directory to contain the database files.
 
  * `cert`
@@ -265,6 +264,53 @@ nsstools::add_cert_and_key { <title>:
     `String` defaults to: `title`
 
     The "nickname" of the certificate in the database.
+
+### `create_cert_and_key`
+
+Create a certificate and it's associated private key directly in an existing NSS database.
+
+```puppet
+nsstools::create_cert_and_key { <title>:
+  nickname => <title>, # defaults to $title
+  subject  => <subject>, # required
+  certdir  => <certdir>, # required
+}
+```
+
+ * `title`
+
+    Used as the default value for the `nickname` parameter.
+
+ * `nickname`
+
+    `String` defaults to: `title`
+
+    The "nickname" of the certificate in the database.
+
+ * `subject`
+
+    `String` required
+
+    The subject of the certificate. The subject identification format follows RFC #1485.
+
+ * `keytype`
+
+    `String` defaults to: 'rsa'
+
+    The type of key to generate with the self signed cert.
+    Valid options: ras|dsa|ec|all
+
+ * `noisefile`
+
+    `String`/absolute path defaults to: '/var/log/messages'
+
+    The path to a file to use as noise to generate the cert. The minimum file size is 20 bytes.
+
+ * `certdir`
+
+    `String`/absolute path required
+
+    Absolute path to the directory that contains the already created NSS database.
 
 ## Functions
 

--- a/manifests/create.pp
+++ b/manifests/create.pp
@@ -42,6 +42,7 @@ define nsstools::create (
   $enable_fips    = false,
 ) {
   include nsstools
+  include nsstools::params
 
   validate_string($password)
   validate_absolute_path($certdir)
@@ -66,7 +67,7 @@ define nsstools::create (
     $require_certdir = undef
   }
 
-  $_password_file = "${certdir}/nss-password.txt"
+  $_password_file = "${certdir}/${nsstools::params::password_file_name}"
   file { $_password_file:
     ensure  => file,
     owner   => $owner,

--- a/manifests/create_cert_and_key.pp
+++ b/manifests/create_cert_and_key.pp
@@ -1,0 +1,58 @@
+# Creates a self signed certificate with key directly in the NSS database.
+#
+# Parameters:
+#   $nickname  - optional - The nickname for the NSS certificate, defaults to the title
+#   $subject   - required - The subject of the certificate.
+#                           The subject identification format follows RFC #1485.
+#   $keytype   - optional - The type of key to generate with the self signed cert.
+#                           Valid options: ras|dsa|ec|all
+#   $noisefile - optional - The path to a file to use as noise to generate the cert.
+#                           The minimum file size is 20 bytes.
+#   $certdir   - required - The path to the NSS DB to add the cert to
+#
+# Actions:
+#  Creates a self signed certifacate directly in the NSS databae.
+#
+# Requires:
+#   $subject
+#   $certdir
+#
+# Sample Usage:
+#
+#   nsstools::create_cert_and_key { 'server_cert':
+#     nickname => 'Servert Cert',
+#     subject  => 'CN=localhost, OU=OrgUnit, O=Org, L=City, ST=State, C=MY\',
+#     certdir  => '/etc/pki/foo',
+#   }
+#
+define nsstools::create_cert_and_key(
+  $nickname  = $title,
+  $subject,
+  $keytype   = 'rsa',
+  $noisefile = '/var/log/messages',
+  $certdir,
+) {
+  include nsstools
+  include nsstools::params
+
+  validate_string($nickname)
+  validate_string($subject)
+  validate_re($keytype, [ '^rsa', '^dsa', '^ec', '^all' ])
+  validate_absolute_path($certdir)
+  validate_absolute_path($noisefile)
+
+  $_password_file = "${certdir}/${nsstools::params::password_file_name}"
+
+  # create the cert and key in the NSS database
+  exec { "create_cert_and_key_${title}":
+    path      => ['/usr/bin'],
+    command   => "certutil -S -k ${keytype} -n '${nickname}' -t \"u,u,u\" -x -s \"${subject}\" -d ${certdir} -f ${_password_file} -z ${noisefile}",
+    unless    => "certutil -d ${certdir} -L -n '${nickname}'",
+    logoutput => true,
+    require   => [
+      Nsstools::Create[$certdir],
+      File[$_password_file],
+      Class['nsstools'],
+    ],
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,7 @@
 # this class should be considered private
 class nsstools::params {
+  $password_file_name = 'nss-password.txt'
+
   case $::osfamily {
     'redhat': {
       $package_name = ['nss-tools']


### PR DESCRIPTION
This pull request contains two enhancements:
- It adds a new type for creating self signed cert and key directly in the NSS DB rather then using a preexisting key with add_cert_and_key
- It adds an option to the create type for enabling FIPS mode on the DB
