### PR TITLE
Adding support for Ubuntu/Debian

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -6,6 +6,9 @@ class nsstools::params {
     'redhat': {
       $package_name = ['nss-tools']
     }
+    'debian': {
+      $package_name = ['libnss3-tools']
+    }
     default: {
       fail("Module ${module_name} is not supported on ${::operatingsystem}")
     }


### PR DESCRIPTION
certutil is provided by package libnss3-tools on Ubuntu/Debian